### PR TITLE
Updating Lab 8 debugging instructions

### DIFF
--- a/lab-8-websockets.html
+++ b/lab-8-websockets.html
@@ -128,8 +128,9 @@ If there is an error about Xcode, you may need to install it: <a href="https://d
 <p>If there is an error like <code>favicon.ico: Invalid Version: undefined</code> 
 this is because of a bug in parcel bundler 1.12.4, so downgrade to 1.12.3 by
 running <code>npm install parcel-bundler@1.12.3</code>.</p>
-<p> If you encounter an error like <code>Cannot find module 'ws'</code> after running <code>npm start</code> and you installed Node with NVM,
-try downgrading your Node version to 10.15.1 with the command <code>npm install 10.15.1</code>.</p>
+<p> If you encounter an error like <code>Cannot find module 'ws'</code> after running <code>npm start</code>,
+try downgrading your Node version to 10.15.1 with the command <code>npm install 10.15.1</code> OR <code>nvm install 10.15.1</code> 
+(depending on which package manager you're using).</p>
 <p><strong>Question 1</strong>: What do you see in the browser? When you open another tab and perform a click/drag action, what happens?</p>
 <p><strong>Question 2</strong>: What are some of the differences between TypeScript and JavaScript?</p>
 <p><strong>Question 3</strong>: Why is a web application bundler (Parcel, Webpack, Rollup, etc.) useful for modern web projects? What are some features that <a href="https://parceljs.org/">ParcelJS</a> provides?</p>


### PR DESCRIPTION
I updated the instructions for lab 8 to account for an additional bug we found during lab today (11/15/21). The solution previously added for the 'cannot find module 'ws'' bug didn't work for some people, so I added in the workaround fix as well. 