### PR TITLE
instructions for downgrading node version on mac

### DIFF
--- a/lab-8-websockets.html
+++ b/lab-8-websockets.html
@@ -108,6 +108,20 @@ npm<span class="w"> </span>--version
 <span class="c1"># 6.7.0</span>
 </code></pre></div>
 
+<h4>Option 3: Downgrading Node on Mac</h4>
+<p>If you already have node.js installed, and want to downgrade to a version, you can use 
+  <code>n</code>
+  to manage node versions.</p>  
+</p>
+<p>Run this:</p>
+<div class="highlight"><pre><span></span><code>$ npm install -g n
+$ n 11.10.0
+</code></pre></div>
+<p>Now you can check your version:</p>
+<div class="highlight"><pre><span></span><code>node<span class="w"> </span>--version
+<span class="c1"># v11.10.0</span>
+</code></pre></div>
+<p>This does not work for Windows OS (try this instead: <a href"https://phoenixnap.com/kb/downgrade-node-version-windows" >https://phoenixnap.com/kb/downgrade-node-version-windows)</a></p>
 <h3>Initialize Phaser and WebSockerServer</h3>
 <p>Fork this repository and clone it locally onto your own machine.</p>
 <ul>


### PR DESCRIPTION
Added instructions so that Mac users can downgrade their node since the latest version of node does not support the lab.