### PR TITLE
Improve serializer part for Heroku lab

### DIFF
--- a/content/labsignments/heroku.md
+++ b/content/labsignments/heroku.md
@@ -1410,7 +1410,7 @@ curl -X POST http://localhost:8000/polls/api/question/add/ \
 - MUST create a `MultipleChoiceQuestion` and multiple `MultipleChoiceOption` when the payload is valid
     - MUST respond with a status code of 201 after it was created
 
-**Hint**: You'll need to use nested serializers for this task! Look at the "Working with Related Models Using Nested Serializers" section above. You can create a `ChoiceOptionSerializer` for the choice objects and a `QuestionWithChoicesSerializer` that includes the nested choices. The validation will be handled automatically by the serializers based on your model field constraints! ([Documentation](https://www.django-rest-framework.org/api-guide/serializers/))
+**Hint**: You'll need to use nested serializers for this task! You can create a `ChoiceOptionSerializer` for the choice objects and a `QuestionWithChoicesSerializer` that includes the nested choices. The validation will be handled automatically by the serializers based on your model field constraints! ([Documentation](https://www.django-rest-framework.org/api-guide/serializers/))
 
 ### TASK - Comment Section
 


### PR DESCRIPTION
1. Provide students with base code using ModelSerializer instead of Serializer to make it easier to catch up. 
2. Include example code demonstrating both Serializer and BaseSerializer for learning purposes.
3. Update the payload for the “TASK - Question Creation Route” to make serializer implementation simpler:
```json
{
  "question_text": "Should pineapple be on pizza?",
  "choice_options": [
    {"choice_text": "yes"},
    {"choice_text": "no"}
  ]