### PR TITLE
Fixed the typo in one of the comments API to get the comment using the FQID

### DIFF
--- a/content/general/project.md
+++ b/content/general/project.md
@@ -1200,7 +1200,7 @@ shortcut to get the image if authenticated to see it.
 * URL: `://service/api/entries/{ENTRY_FQID}/comments`
     * `GET` [local, remote]: the comments on the entry (that our server knows about)
     * Body is a ["comments" object](#example-comments-object)
-* URL: `://service/api/authors/{AUTHOR_SERIAL}/entries/{ENTRY_SERIAL}/comment/{REMOTE_COMMENT_FQID}`
+* URL: `://service/api/authors/{AUTHOR_SERIAL}/entries/{ENTRY_SERIAL}/comments/{REMOTE_COMMENT_FQID}`
     * GET [local, remote] get the comment
 * Example: GET `http://nodebbbb/api/authors/222/entries/249/comments/http%3A%2F%2Fnodeaaaa%2Fapi%2Fauthors%2F111%2Fcommented%2F130`:
 


### PR DESCRIPTION
<img width="758" height="106" alt="image" src="https://github.com/user-attachments/assets/ac5c0063-74d4-4bdb-a4bf-83553a196f8c" />

It should have been comments rather than comment according to the example. Plus all the other endpoints use comments and not comment.