### PR TITLE
Fix small errors: duplicate IDs, outline title, typos, link, duplicate font rule

### DIFF
--- a/content/general/grade_letters.md
+++ b/content/general/grade_letters.md
@@ -71,7 +71,7 @@ apply to everyone.
         * The class average can be an A.
 * Instructors can not decide to make the breakpoints just whatever they want. Breakpoints are validated by at least one of:
     * Associate Chair (Undergraduate Program)
-    * Associate Chain (Graduate Program)
+    * Associate Chair (Graduate Program)
     * Department Chair
 * Almost nothing in the course outline (syllabus) can be changed after the first day of class. Especially not component weights, like the weights of an exam.
 * Everyone in the class can get an A at the same time in the same semester.

--- a/content/general/individual.md
+++ b/content/general/individual.md
@@ -35,7 +35,7 @@ You can earn lecture participation credit by attending lectures on time. Instruc
 As of Fall 2025, [Wooclap](https://www.wooclap.com/) is used for lecture participation.
 
 * You must login with your ualberta email address to get credit.
-    * You will not get credit for your using any other account.
+    * You will not get credit for you using any other account.
 * For lecture participation, some of the lowest marks are dropped. No extensions, excused absences, or weight transfers are possible. See the [outline]({filename}/general/outline.md#missed-term-work-participation) for more information.
 * Entering answers in Wooclap without attending the course, either in-person or on Zoom will be considered a violation of the Student Academic Integrity Policy.
     * Entering answers for someone else will be considered a violation of the SAIP.

--- a/content/general/individual.md
+++ b/content/general/individual.md
@@ -35,7 +35,7 @@ You can earn lecture participation credit by attending lectures on time. Instruc
 As of Fall 2025, [Wooclap](https://www.wooclap.com/) is used for lecture participation.
 
 * You must login with your ualberta email address to get credit.
-    * You will not get credit for you using any other account.
+    * You will not get credit if you use any other account.
 * For lecture participation, some of the lowest marks are dropped. No extensions, excused absences, or weight transfers are possible. See the [outline]({filename}/general/outline.md#missed-term-work-participation) for more information.
 * Entering answers in Wooclap without attending the course, either in-person or on Zoom will be considered a violation of the Student Academic Integrity Policy.
     * Entering answers for someone else will be considered a violation of the SAIP.

--- a/content/general/labs.md
+++ b/content/general/labs.md
@@ -9,7 +9,7 @@ summary: Lab Procedure, Lab Assignments, Lab Marking
 
 [TOC]
 
-* [Development Environment]({filename}environment.md)
+* [Development Environment]({filename}/general/environment.md)
 * [How to avoid Force Push & Rebase]({filename}/general/dontforcepush.md)
 
 # Lab Procedure

--- a/content/general/outline.md
+++ b/content/general/outline.md
@@ -75,11 +75,11 @@ summary: Lecture, Labs, Contact Information, Lecturer, Teaching Assistants, Cour
 
 Course outlines / course syllabuses have moved to the centralized UA syllabus repository. 
 
-* <h4 id="winter2026">CMPUT 404 Winter 2026 B1</h4>
+* <h4 id="winter2026b1">CMPUT 404 Winter 2026 B1</h4>
 
     * <a href="https://ualberta.simplesyllabusca.com/doc/p7hcd8nsk/Winter-2026-CMPUT-404-B1-%2885293%29-WEB-APPLICATIONS-AND-ARCHITECT?mode=view">UAlberta Syllabus Page</a> or <a href="https://ualberta.simplesyllabusca.com/api2/doc-pdf/p7hcd8nsk/Winter-2026-CMPUT-404-B1-%2885293%29-WEB-APPLICATIONS-AND-ARCHITECT.pdf?locale=en-US">PDF</a>
 
-* <h4 id="winter2026">CMPUT 404 Winter 2026 B2</h4>
+* <h4 id="winter2026b2">CMPUT 404 Winter 2026 B2</h4>
 
     * <a href="https://ualberta.simplesyllabusca.com/doc/tanb1qe44/Winter-2026-CMPUT-404-B2-%2889668%29-WEB-APPLICATIONS-AND-ARCHITECT?mode=view">UAlberta Syllabus Page</a> or <a href="https://ualberta.simplesyllabusca.com/api2/doc-pdf/tanb1qe44/Winter-2026-CMPUT-404-B2-%2889668%29-WEB-APPLICATIONS-AND-ARCHITECT.pdf?locale=en-US">PDF</a>
 

--- a/content/general/outline202409.md
+++ b/content/general/outline202409.md
@@ -1,4 +1,4 @@
-Title: Course Outline Winter 2024
+Title: Course Outline Fall 2024
 date: 2024-09-01
 tags: outline, policy, grading, contact
 authors: Hazel Victoria Campbell

--- a/templates/cmput404/static/style.css
+++ b/templates/cmput404/static/style.css
@@ -108,12 +108,6 @@
 }
 @font-face {
   font-family: "Atkinson Hyperlegible Next";
-  font-weight: 600;
-  font-style: normal;
-  src: url(hyperlegible/AtkinsonHyperlegibleNext-SemiBold.woff2);
-}
-@font-face {
-  font-family: "Atkinson Hyperlegible Next";
   font-weight: 1 1000;
   font-style: normal;
   src: url(hyperlegible/AtkinsonHyperlegibleNextVF-Variable.woff2);


### PR DESCRIPTION
- outline.md: fix duplicate HTML id (winter2026 → winter2026b1 / winter2026b2)
- outline202409.md: correct title Winter 2024 → Fall 2024
- grade_letters.md: typo Associate Chain → Associate Chair
- individual.md: grammar "your  using" → "you using"
- labs.md: fix Development Environment link to /general/environment.md
- style.css: remove duplicate @font-face for Atkinson Hyperlegible Next SemiBold