### PR TITLE
Fixed broken links to the collaboration information on the lab pages

### DIFF
--- a/content/labsignments/flask.md
+++ b/content/labsignments/flask.md
@@ -222,5 +222,5 @@ You can submit and then resubmit as many times as you want before the deadline, 
 * Collaboration must be documented in your source code.
 * Any source code you got from anywhere else must be cited in the source code. This includes code from LLMs.
 * You can only use source code that **you understand**: see the [lab marking info]({filename}/general/labs.md#lab-marking)
-* For more information see the collaboration section in the outline: [{filename}/general/outline.md#consultation-assignments-labs]
+* For more information see the [collaboration section in the outline]({filename}/general/outline.md#consultation-assignments-labs)
 

--- a/content/labsignments/heroku.md
+++ b/content/labsignments/heroku.md
@@ -1652,7 +1652,7 @@ After you receive your grade, you can delete your Heroku app to save credits/mon
 * Collaboration must be documented in your source code.
 * Any source code you got from anywhere else must be cited in the source code. This includes code from LLMs.
 * You can only use source code that **you understand**: see the [lab marking info]({filename}/general/labs.md#lab-marking)
-* For more information see the collaboration section in the outline: [{filename}/general/outline.md#consultation-assignments-labs]
+* For more information see the [collaboration section in the outline]({filename}/general/outline.md#consultation-assignments-labs)
 
 # Tips
 

--- a/content/labsignments/http-old.md
+++ b/content/labsignments/http-old.md
@@ -32,6 +32,7 @@ You are meant to understand the very basics of HTTP by having a hands-on ground 
 * Collaboration must be documented in your source code.
 * Any source code you got from anywhere else must be cited in the source code.
 * You can only use source code that **you understand**: see the [lab marking info]({filename}/general/labs.md#lab-marking)
+* For more information see the [collaboration section in the outline]({filename}/general/outline.md#consultation-assignments-labs)
 
 # User Stories
 

--- a/content/labsignments/http.md
+++ b/content/labsignments/http.md
@@ -46,6 +46,7 @@ The webserver will serve static content from the `www` directory in the same dir
         * Code from this course's slides
         * The starter code from GitHub Classroom
         * Code written by an instructor or TA and hosted on this website: `uofa-cmput404.github.io`
+* For more information see the [collaboration section in the outline]({filename}/general/outline.md#consultation-assignments-labs)
 
 # User Stories
 
@@ -356,7 +357,7 @@ You can submit and then resubmit as many times as you want before the deadline, 
 * Collaboration must be documented in your source code.
 * Any source code you got from anywhere else must be cited in the source code. This includes code from LLMs.
 * You can only use source code that **you understand**: see the [lab marking info]({filename}/general/labs.md#lab-marking)
-* For more information see the collaboration section in the outline: [{filename}/general/outline.md#consultation-assignments-labs]
+* For more information see the [collaboration section in the outline]({filename}/general/outline.md#consultation-assignments-labs)
 
 # Tips
 

--- a/content/labsignments/pelican.md
+++ b/content/labsignments/pelican.md
@@ -611,6 +611,6 @@ You can submit and then resubmit as many times as you want before the deadline, 
 * Collaboration must be documented in your source code.
 * Any source code you got from anywhere else must be cited in the source code. This includes code from LLMs.
 * You can only use source code that **you understand**: see the [lab marking info]({filename}/general/labs.md#lab-marking)
-* For more information see the collaboration section in the outline: [{filename}/general/outline.md#consultation-assignments-labs]
+* For more information see the [collaboration section in the outline]({filename}/general/outline.md#consultation-assignments-labs)
 
 


### PR DESCRIPTION
This PR fixes the broken markdown links on the "Labs" pages that linked to the outline's collaboration policy section. (Assuming that the outline was still on site and not in the central repository.)