### PR TITLE
Updated 'Deploy Django' link and Tango With Django link

### DIFF
--- a/content/general/resources.md
+++ b/content/general/resources.md
@@ -59,8 +59,7 @@ Some reference materials taken from https://github.com/vhf/free-programming-book
 <!-- *   [Django by Example for Django 1.5](http://lightbird.net/dbe2/) \https://web.archive.org/web/20141223005244/http://www.lightbird.net/dbe -->
 *   [Djen of Django](http://agiliq.com/books/djenofdjango/)
 *   [Effective Django](https://web.archive.org/web/20181130092020/http://www.effectivedjango.com/)
-*   [Tango With Django](http://www.tangowithdjango.com/book/)
-*   [Deploy Django](http://www.deploydjango.com)
+*   [Deploy Django](https://docs.djangoproject.com/en/6.0/howto/deployment/)
 *   [The Django Book](http://www.djangobook.com)
 *   [Tango With Django](http://www.tangowithdjango.com/)
 


### PR DESCRIPTION
Updated the link for 'Deploy Django' to the official documentation.

Removed the duplicate Tango With Django link